### PR TITLE
Fixed: 'Expected an option. Instead got: -c' when using spi

### DIFF
--- a/src/mpsse-cli.c
+++ b/src/mpsse-cli.c
@@ -122,17 +122,13 @@ static uint32 printMPSSEchannelInfo(int channels) {
 }
 
 int8 checkIfArgIsOption(char *arg) {
-    char firstChar = 0x00;
-
     if( arg == NULL )
      return -1;
 
     // Make sure the provided arg is actually there
     if( strlen(arg) > 0 ) {
-        // Grab the first character
-        memcpy(&firstChar, arg, 0x01);
-        // We have SOMETHING.. Check that the first character is at least a "-".
-        if( !strcmp(&firstChar, "-") ) {
+        // Check that the first character is at least a "-".
+        if(strncmp(arg, "-", 1) == 0 ) {
             return 0;
         }
         else {


### PR DESCRIPTION
Fixed `Expected an option. Instead got: -c` when using any spi command

old behaviour:
```
# ./mpsse-cli spi -c 0 -w -l 2 -d 0x40,0x00
Expected an option. Instead got: -c
# ./mpsse-cli spi-c 0 -w -l 2 -d 0x40,0x00 
Invalid arguments given.
# ./mpsse-cli spi -c 0 -w -l 2 -d 0x40,0x00
Expected an option. Instead got: -c
# ./mpsse-cli spi -c 0 -x w -l 2 -d 0x40,0x00
Expected an option. Instead got: -c
# ./mpsse-cli spi -c 0 -x w -l 8 -d 0xDD,0xEE,0xAA,0xDD,0xBB,0xEE,0xEE,0xFF
Expected an option. Instead got: -c
# ./mpsse-cli spi -x w -l 8 -d 0xDD,0xEE,0xAA,0xDD,0xBB,0xEE,0xEE,0xFF 
Expected an option. Instead got: -x
# ./mpsse-cli spi --xfer w -l 8 -d 0xDD,0xEE,0xAA,0xDD,0xBB,0xEE,0xEE,0xFF
Expected an option. Instead got: --xfer
# ./mpsse-cli spi -h
usage: mpsse-cli spi [...option]
```
new behaviour:
```
# mpsse-cli spi -c 0 -x w -l 8 -d 0xDD,0xEE,0xAA,0xDD,0xBB,0xEE,0xEE,0xFF
Starting a WRITE on channel 0 with a len of 8 bytes at 100000Hz.
8 bytes written over spi.
```